### PR TITLE
Eliminate the need for an indexing lookup table

### DIFF
--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -1,9 +1,8 @@
-const NucleicAcidlookup8 = [0x01, 0x02, 0x00, 0x03, 0x00, 0x00, 0x00, 0x04]
 
-function getindex{T <: Union{DNA, RNA}}(x::SMatrix{4, 4}, i::T, j::T)
-  return x[NucleicAcidlookup8[reinterpret(UInt8, i)], NucleicAcidlookup8[reinterpret(UInt8, j)]]
+function getindex(x::SMatrix{4, 4}, i::T, j::T) where T <: Union{DNA, RNA}
+    return x[trailing_zeros(i) + 1, trailing_zeros(j) + 1]
 end
 
-function getindex{T <: Union{DNA, RNA}}(x::MMatrix{4, 4}, i::T, j::T)
-  return x[NucleicAcidlookup8[reinterpret(UInt8, i)], NucleicAcidlookup8[reinterpret(UInt8, j)]]
+function getindex(x::MMatrix{4, 4}, i::T, j::T) where T <: Union{DNA, RNA}
+    return x[trailing_zeros(i) + 1, trailing_zeros(j) + 1]
 end


### PR DESCRIPTION
This PR eliminates the need for a lookup table, requiring less memory and no requirement of cache. The values are simply computed from the nucleotides provided, often by specific, efficient processor instructions.