### PR TITLE
Edits to CI infrastructure

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,1 +1,0 @@
-comment: false

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.jl.mem
 docs/build/
 docs/site/
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,33 +5,10 @@ os:
   - osx
 julia:
   - 0.6
-  - nightly
 notifications:
   email: false
-git:
-  depth: 99999999
-
-## uncomment the following lines to allow failures on nightly julia
-## (tests will run but not make your overall status red)
-#matrix:
-#  allow_failures:
-#  - julia: nightly
-
-## uncomment and modify the following lines to manually install system packages
-#addons:
-#  apt: # apt-get for linux
-#    packages:
-#    - gfortran
-#before_script: # homebrew for mac
-#  - if [ $TRAVIS_OS_NAME = osx ]; then brew install gcc; fi
-
-## uncomment the following lines to override the default test script
-#script:
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("SubstitutionModels"); Pkg.test("SubstitutionModels"; coverage=true)'
 after_success:
-  # push coverage results to Coveralls
-  - julia -e 'cd(Pkg.dir("SubstitutionModels")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
-  # push coverage results to Codecov
+  # Push coverage results to Codecov
   - julia -e 'cd(Pkg.dir("SubstitutionModels")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
   - julia -e 'Pkg.add("Documenter")'
   - julia -e 'cd(Pkg.dir("SubstitutionModels")); include(joinpath("docs", "make.jl"))'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,15 +2,6 @@ environment:
   matrix:
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
-
-## uncomment the following lines to allow failures on nightly julia
-## (tests will run but not make your overall status red)
-#matrix:
-#  allow_failures:
-#  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-#  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 
 branches:
   only:


### PR DESCRIPTION
This edits the CI files in a few ways to be consistent with other BioJulia ecosystem packages.

We used to use coveralls and codecov. But eventually we changed to just use codecov. It seemed redundant to use both.

We used to test nightlies and allow failures for them, but nightlies almost always fail for reasons entirely unrelated to the package, and so the extra CI time required seemed somewhat a drag, for no real gain. Now we just test on julia versions supported by the package. At the present time most of the packages are dropping 0.5 support and going to 0.6 as we want to encourage rapid adoption of latest julia syntax, especially given the rather stark differences between 0.5 and 0.6.