### PR TITLE
Updates for Julia 0.7/1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,16 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
+  - 0.7
+  - 1.0
+  - nightly
 notifications:
   email: false
+matrix:
+  allow_failures:
+    - julia: nightly
+  fast_finish: true
 after_success:
-  # Push coverage results to Codecov
-  - julia -e 'cd(Pkg.dir("SubstitutionModels")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
-  - julia -e 'Pkg.add("Documenter")'
-  - julia -e 'cd(Pkg.dir("SubstitutionModels")); include(joinpath("docs", "make.jl"))'
+  - julia -e 'using Pkg; Pkg.add("Documenter"); Pkg.add("Coverage")'
+  - julia -e 'using Coverage; import SubstitutionModels; cd(dirname(dirname(pathof(SubstitutionModels)))); Codecov.submit(process_folder())'
+  - julia -e 'import SubstitutionModels; cd(dirname(dirname(pathof(SubstitutionModels)))); include(joinpath("docs", "make.jl"))'

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ The current release version can be installed
 from the Julia REPL:
 
 ```julia
-julia> Pkg.add("SubstitutionModels")
+julia> using Pkg
+julia> add("SubstitutionModels")
 ```
 
 ## Contributing and Questions

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.6
-BioSymbols 1.2.0
-StaticArrays 0.6.1
+julia 0.7
+BioSymbols
+StaticArrays

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 
 branches:
   only:
@@ -16,11 +15,6 @@ notifications:
 
 install:
   - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# If there's a newer build queued for the same PR, cancel this one
-  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
-        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
-        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
-        throw "There are newer queued builds for this pull request, failing early." }
 # Download most recent Julia Windows binary
   - ps: (new-object net.webclient).DownloadFile(
         $env:JULIA_URL,

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,7 +18,7 @@ makedocs(
 
 deploydocs(
     repo = "github.com/BioJulia/SubstitutionModels.jl.git",
-    julia = "0.6",
+    julia = "0.7",
     osname = "linux",
     target = "build",
     deps = nothing,

--- a/docs/src/man/modeltypes.md
+++ b/docs/src/man/modeltypes.md
@@ -50,7 +50,7 @@ directly by defining a new method for the `Q` function.
 P matrices are calculated as follows through matrix exponentiation:
 
 ```math
-P = \text{expm} \left(Q \times t \right).
+P = \text{exp} \left(Q \times t \right).
 ```
 
 SubstitutionModels.jl provides generic methods that perform this exponentiation

--- a/src/SubstitutionModels.jl
+++ b/src/SubstitutionModels.jl
@@ -1,5 +1,3 @@
-__precompile__()
-
 module SubstitutionModels
 
   using
@@ -9,7 +7,9 @@ module SubstitutionModels
 
   import
     Base.getindex,
-    Base.show
+    Base.show,
+    Base.setindex!,
+    Base.checkbounds
 
   include("core.jl")
   include("indexing.jl")

--- a/src/SubstitutionModels.jl
+++ b/src/SubstitutionModels.jl
@@ -4,7 +4,8 @@ module SubstitutionModels
 
   using
     BioSymbols,
-    StaticArrays
+    StaticArrays,
+    LinearAlgebra
 
   import
     Base.getindex,

--- a/src/core.jl
+++ b/src/core.jl
@@ -4,7 +4,7 @@ abstract type SubstitutionModel end
 const SM = SubstitutionModel
 
 
-doc"""
+@doc doc"""
 `NucleicAcidSubstitutionModel` is an abstract type that contains all models
 describing a substitution process impacting biological sequences of `DNA` or
 `RNA` with continous time Markov models.

--- a/src/core.jl
+++ b/src/core.jl
@@ -4,7 +4,7 @@ abstract type SubstitutionModel end
 const SM = SubstitutionModel
 
 
-@doc doc"""
+"""
 `NucleicAcidSubstitutionModel` is an abstract type that contains all models
 describing a substitution process impacting biological sequences of `DNA` or
 `RNA` with continous time Markov models.

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -1,17 +1,38 @@
-
-@inline function Base.checkbounds(x::SMatrix{4, 4}, i::T, j::T) where T <: NucleicAcid
-    if iscertain(i) && iscertain(j)
-        return true
-    end
-    throw(BoundsError(x, i, j))
+@inline function checkbounds(a::AbstractArray, i::T, j::T) where T <: NucleicAcid
+  if iscertain(i) & iscertain(j)
+    return true
+  end
+  checkbounds(a, trailing_zeros(i) + 1, trailing_zeros(j) + 1)
 end
 
-@inline function getindex(x::SMatrix{4, 4}, i::T, j::T) where T <: NucleicAcid
-    @boundscheck checkbounds(x, i, j)
-    @inbounds return x[trailing_zeros(i) + 1, trailing_zeros(j) + 1]
+
+@inline function checkbounds(a::AbstractArray, i::NucleicAcid)
+  if iscertain(i)
+      return true
+  end
+  checkbounds(a, trailing_zeros(i) + 1)
 end
 
-@inline function getindex(x::MMatrix{4, 4}, i::T, j::T) where T <: NucleicAcid
-    @boundscheck checkbounds(x, i, j)
-    @inbounds return x[trailing_zeros(i) + 1, trailing_zeros(j) + 1]
+
+@inline function getindex(a::AbstractArray, i::T, j::T) where T <: NucleicAcid
+  @boundscheck checkbounds(a, i, j)
+  @inbounds return a[trailing_zeros(i) + 1, trailing_zeros(j) + 1]
+end
+
+
+@inline function getindex(a::AbstractArray, i::NucleicAcid)
+  @boundscheck checkbounds(a, i)
+  @inbounds return a[trailing_zeros(i) + 1]
+end
+
+
+@inline function setindex!(a::AbstractArray, x, i::T, j::T) where T <: NucleicAcid
+  @boundscheck checkbounds(a, i, j)
+  @inbounds return setindex!(a, x, trailing_zeros(i) + 1, trailing_zeros(j) + 1)
+end
+
+
+@inline function setindex!(a::AbstractArray, x, i::NucleicAcid)
+  @boundscheck checkbounds(a, i)
+  @inbounds return setindex!(a, x, trailing_zeros(i) + 1)
 end

--- a/src/nucleic_acid/nucleic_acid.jl
+++ b/src/nucleic_acid/nucleic_acid.jl
@@ -14,7 +14,7 @@ _πR(mod::NASM) = _πA(mod) + _πG(mod)
 _πY(mod::NASM) = _πT(mod) + _πC(mod)
 
 
-doc"""
+@doc doc"
 Generate a Q matrix for a `NucleicAcidSubstitutionModel`, of the form:
 
 ```math
@@ -24,7 +24,7 @@ Q_{C, A} & Q_{C, C} & Q_{C, G} & Q_{C, T} \\
 Q_{G, A} & Q_{G, C} & Q_{G, G} & Q_{G, T} \\
 Q_{T, A} & Q_{T, C} & Q_{T, G} & Q_{T, T} \end{bmatrix}
 ```
-"""
+"
 @inline function Q(mod::NASM)
     α = _α(mod)
     β = _β(mod)
@@ -48,7 +48,7 @@ end
     if t < 0.0
         error("t must be positive")
     end
-    return expm(Q(mod) * t)
+    return exp(Q(mod) * t)
 end
 
 
@@ -58,15 +58,15 @@ function P_generic(mod::NASM, t::Array{Float64})
     end
     try
         eig_vals, eig_vecs = eig(Q(mod))
-        return [eig_vecs * expm(diagm(eig_vals)*i) * eig_vecs' for i in t]
+        return [eig_vecs * exp(diagm(eig_vals)*i) * eig_vecs' for i in t]
     catch
         eig_vals, eig_vecs = eig(Array(Q(mod)))
-        return [SMatrix(eig_vecs * expm(diagm(eig_vals)*i) * eig_vecs') for i in t]
+        return [SMatrix(eig_vecs * exp(diagm(eig_vals)*i) * eig_vecs') for i in t]
     end
 end
 
 
-doc"""
+@doc doc"
 Generate a P matrix for a `NucleicAcidSubstitutionModel`, of the form:
 
 ```math
@@ -78,5 +78,5 @@ P_{T, A} & P_{T, C} & P_{T, G} & P_{T, T} \end{bmatrix}.
 ```
 
 for specified time
-"""
+"
 P(mod::NASM, t) = P_generic(mod, t)

--- a/src/nucleic_acid/nucleic_acid.jl
+++ b/src/nucleic_acid/nucleic_acid.jl
@@ -14,7 +14,7 @@ _πR(mod::NASM) = _πA(mod) + _πG(mod)
 _πY(mod::NASM) = _πT(mod) + _πC(mod)
 
 
-@doc doc"
+"""
 Generate a Q matrix for a `NucleicAcidSubstitutionModel`, of the form:
 
 ```math
@@ -24,7 +24,7 @@ Q_{C, A} & Q_{C, C} & Q_{C, G} & Q_{C, T} \\
 Q_{G, A} & Q_{G, C} & Q_{G, G} & Q_{G, T} \\
 Q_{T, A} & Q_{T, C} & Q_{T, G} & Q_{T, T} \end{bmatrix}
 ```
-"
+"""
 @inline function Q(mod::NASM)
     α = _α(mod)
     β = _β(mod)
@@ -66,7 +66,7 @@ function P_generic(mod::NASM, t::Array{Float64})
 end
 
 
-@doc doc"
+"""
 Generate a P matrix for a `NucleicAcidSubstitutionModel`, of the form:
 
 ```math
@@ -78,5 +78,5 @@ P_{T, A} & P_{T, C} & P_{T, G} & P_{T, T} \end{bmatrix}.
 ```
 
 for specified time
-"
+"""
 P(mod::NASM, t) = P_generic(mod, t)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using SubstitutionModels
 using BioSymbols
-using Base.Test
+using Test
+using LinearAlgebra
 
 
 import SubstitutionModels._π,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using SubstitutionModels
 using BioSymbols
 using Test
 using LinearAlgebra
+using StaticArrays
 
 
 import SubstitutionModels._π,
@@ -120,4 +121,11 @@ end
   @test isapprox(diag(P(testmod2, 1.0e9)), _π(testmod2), atol = 1.0e-5)
   @test sum(_π(testmod1)) == 1.0
   @test sum(_π(testmod2)) == 1.0
+end
+
+@testset "Indexing" begin
+  testmat = MMatrix{4, 4,Int64}(1:16)
+  @test testmat[DNA_A] == testmat[DNA_A, DNA_A]
+  testmat[DNA_G] = 100
+  @test testmat[DNA_G] == 100
 end


### PR DESCRIPTION
I have provided some very small changes for Julia 1.0 compatibility. 

I have also provided a fix to indexing various Substitution Model matrices by `NucleicAcids`, and have added a test for this indexing functionality.