### PR TITLE
:art: changed substitution models to be mutable with setrate! function

### DIFF
--- a/docs/src/man/models.md
+++ b/docs/src/man/models.md
@@ -1,6 +1,6 @@
 # SubstitutionModels.jl
 
-## What are subsitution models?
+## What are substitution models?
 
 Substitution models are phenomenological descriptions of the evolution of DNA,
 as a string of four discrete states. A, T (U in RNA), C, and G.
@@ -23,4 +23,11 @@ to transversions.
 
 ```@docs
 NucleicAcidSubstitutionModel
+```
+
+## Update model rates:
+
+NucleicAcidSbustitutionModel object rates can be modified using the `setrate!` function.
+```@docs
+setrate!
 ```

--- a/src/SubstitutionModels.jl
+++ b/src/SubstitutionModels.jl
@@ -46,6 +46,7 @@ module SubstitutionModels
     HKY85, HKY85abs, HKY85rel,
     TN93, TN93abs, TN93rel,
     GTR, GTRabs, GTRrel,
-    Q, P
+    Q, P,
+    setrate!
 
 end # module

--- a/src/nucleic_acid/f81/absolute.jl
+++ b/src/nucleic_acid/f81/absolute.jl
@@ -1,4 +1,4 @@
-struct F81abs <: F81
+mutable struct F81abs <: F81
   β::Float64
   πA::Float64
   πC::Float64
@@ -17,6 +17,43 @@ struct F81abs <: F81
   end
 end
 
+"""
+```julia-repl
+julia> model = F81(0.6, 0.25, 0.25, 0.25, 0.25);
+
+julia> setrate!(model, [0.5, 0.25, 0.25, 0.25, 0.25])
+Felsenstein 1981 model (absolute rate form)
+β = 0.5, π = [0.25, 0.25, 0.25, 0.25]
+```
+"""
+@inline function setrate!(mod::F81abs, rate::Vector{Float64})
+  #check length of vector
+  if length(rate) != 5
+    @error "F81 rate must be a vector of length 5"
+  else 
+    #separate vector into pieces
+    β = rate[1]
+    πA = rate[2]
+    πC = rate[3]
+    πG = rate[4]
+    πT = rate[5]
+    #check correctness of rates
+    if β <= 0.
+      @error "F81 parameter β must be positive"
+    elseif sum([πA,πC,πG,πT]) != 1.0
+      @error "F81 frequencies must sum to 1.0"
+    elseif any([πA,πC,πG,πT] .<=0.0)
+      @error "F81 frequencies must be positive"
+    end
+    #add rates
+    mod.β = β
+    mod.πA = πA
+    mod.πC = πC
+    mod.πG = πG
+    mod.πT = πT
+  end
+  return mod
+end
 
 function show(io::IO, object::F81abs)
   print(io, "\r\e[0m\e[1mF\e[0melsenstein 19\e[1m81\e[0m model (absolute rate form)

--- a/src/nucleic_acid/f81/relative.jl
+++ b/src/nucleic_acid/f81/relative.jl
@@ -1,4 +1,4 @@
-struct F81rel <: F81
+mutable struct F81rel <: F81
   πA::Float64
   πC::Float64
   πG::Float64
@@ -13,6 +13,39 @@ struct F81rel <: F81
   end
 end
 
+"""
+```julia-repl
+julia> model = F81(0.25, 0.25, 0.25, 0.25);
+
+julia> setrate!(model, [0.25, 0.25, 0.25, 0.25])
+Felsenstein 1981 model (relative rate form)
+π = [0.25, 0.25, 0.25, 0.25]
+```
+"""
+@inline function setrate!(mod::F81rel, rate::Vector{Float64})
+  #check length of vector
+  if length(rate) != 4
+    @error "F81 rate must be a vector of length 4"
+  else 
+    #separate vector into pieces
+    πA = rate[1]
+    πC = rate[2]
+    πG = rate[3]
+    πT = rate[4]
+    #check correctness of rates (from above)
+    if sum([πA,πC,πG,πT]) != 1.0
+      @error "F81 frequencies must sum to 1.0"
+    elseif any([πA,πC,πG,πT] .<=0.0)
+      @error "F81 frequencies must be positive"
+    end
+    #add rate
+    mod.πA = πA
+    mod.πC = πC
+    mod.πG = πG
+    mod.πT = πT
+  end
+  return mod
+end
 
 function show(io::IO, object::F81rel)
   print(io, "\r\e[0m\e[1mF\e[0melsenstein 19\e[1m81\e[0m model (relative rate form)

--- a/src/nucleic_acid/f84/absolute.jl
+++ b/src/nucleic_acid/f84/absolute.jl
@@ -1,4 +1,4 @@
-struct F84abs <: F84
+mutable struct F84abs <: F84
   κ::Float64
   β::Float64
   πA::Float64
@@ -20,6 +20,47 @@ struct F84abs <: F84
   end
 end
 
+"""
+```julia-repl
+julia> model = F84(0.6, 0.4, 0.25, 0.25, 0.25, 0.25);
+
+julia> setrate!(model, [0.5, 0.5, 0.25, 0.25, 0.25, 0.25])
+Felsenstein 1984 substitution model (absolute rate form)
+κ = 0.5, β = 0.5, π = [0.25, 0.25, 0.25, 0.25]
+```
+"""
+@inline function setrate!(mod::F84abs, rate::Vector{Float64})
+  #check length of vector
+  if length(rate) != 6
+    @error "F84 rate must be a vector of length 6"
+  else 
+    #separate vector into pieces
+    κ = rate[1]
+    β = rate[2]
+    πA = rate[3]
+    πC = rate[4]
+    πG = rate[5]
+    πT = rate[6]
+    #check correctness of rates (from above)
+    if κ <= 0.
+      @error "F84 parameter α must be positive"
+    elseif β <= 0.
+      @error "F84 parameter β must be positive"
+    elseif sum([πA,πC,πG,πT]) != 1.0
+      @error "F84 frequencies must sum to 1.0"
+    elseif any([πA,πC,πG,πT] .<= 0.0)
+      @error "F84 frequencies must be positive"
+    end
+    #assign rates
+    mod.κ = κ
+    mod.β = β
+    mod.πA = πA
+    mod.πC = πC
+    mod.πG = πG
+    mod.πT = πT
+  end
+  return mod
+end
 
 function show(io::IO, object::F84abs)
   print(io, "\r\e[0m\e[1mF\e[0melsenstein 19\e[1m84\e[0m substitution model (absolute rate form)

--- a/src/nucleic_acid/f84/relative.jl
+++ b/src/nucleic_acid/f84/relative.jl
@@ -1,4 +1,4 @@
-struct F84rel <: F84
+mutable struct F84rel <: F84
   κ::Float64
   πA::Float64
   πC::Float64
@@ -15,6 +15,44 @@ struct F84rel <: F84
     end
     new(κ, πA, πC, πG, πT)
   end
+end
+
+"""
+```julia-repl
+julia> model = F84(0.6, 0.25, 0.25, 0.25, 0.25);
+
+julia> setrate!(model, [0.5, 0.25, 0.25, 0.25, 0.25])
+Felsenstein 1984 substitution model (relative rate form)
+κ = 0.5, π = [0.25, 0.25, 0.25, 0.25]
+```
+"""
+@inline function setrate!(mod::F84rel, rate::Vector{Float64})
+  #check length of vector
+  if length(rate) != 5
+    @error "F84 rate must be a vector of length 5"
+  else 
+    #separate vector into pieces
+    κ = rate[1]
+    πA = rate[2]
+    πC = rate[3]
+    πG = rate[4]
+    πT = rate[5]
+    #check correctness of rates (from above)
+    if κ <= 0.
+      @error "F84 parameter κ must be positive"
+    elseif sum([πA,πC,πG,πT]) != 1.0
+      @error "F84 frequencies must sum to 1.0"
+    elseif any([πA,πC,πG,πT] .<=0.0)
+      @error "F84 frequencies must be positive"
+    end
+    #assign rates
+    mod.κ = κ
+    mod.πA = πA
+    mod.πC = πC
+    mod.πG = πG
+    mod.πT = πT
+  end
+  return mod
 end
 
 

--- a/src/nucleic_acid/gtr/absolute.jl
+++ b/src/nucleic_acid/gtr/absolute.jl
@@ -1,4 +1,4 @@
-struct GTRabs <: GTR
+mutable struct GTRabs <: GTR
   α::Float64
   β::Float64
   γ::Float64
@@ -33,6 +33,63 @@ struct GTRabs <: GTR
   end
 end
 
+"""
+```julia-repl
+julia> model = GTR(0.3, 0.6, 0.6, 0.4, 0.4, .6, 0.25, 0.25, 0.25, 0.25);
+
+julia> setrate!(model, [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.25, 0.25, 0.25, 0.25])
+Generalised Time Reversible model (absolute rate form)
+α = 0.5, β = 0.5, γ = 0.5, δ = 0.5, ϵ = 0.5, η = 0.25, π = [0.25, 0.25, 0.25, 0.25]
+```
+"""
+@inline function setrate!(mod::GTRabs, rate::Vector{Float64})
+  #check length of vector
+  if length(rate) != 10
+    @error "GTR rate must be a vector of length 10"
+  else 
+      #separate vector into pieces
+    α = rate[1]
+    β = rate[2]
+    γ = rate[3]
+    δ = rate[4]
+    ϵ = rate[5]
+    η = rate[6]
+    πA = rate[7]
+    πC = rate[8]
+    πG = rate[9]
+    πT = rate[10]
+    #check correctness of rates (from above)
+    if α <= 0.
+      @error "GTR parameter α must be positive"
+    elseif β <= 0.
+      @error "GTR parameter β must be positive"
+    elseif γ <= 0.
+      @error "GTR parameter γ must be positive"
+    elseif δ <= 0.
+      @error "GTR parameter δ must be positive"
+    elseif ϵ <= 0.
+      @error "GTR parameter ϵ must be positive"
+    elseif η <= 0.
+      @error "GTR parameter η must be positive"
+    elseif sum([πA,πC,πG,πT]) != 1.0
+      @error "GTR frequencies must sum to 1.0"
+    elseif any([πA,πC,πG,πT] .<= 0.0)
+      @error "GTR frequencies must be positive"
+    end
+    #add rate
+    mod.α = α
+    mod.β = β
+    mod.γ = γ
+    mod.δ = δ
+    mod.ϵ = ϵ
+    mod.η = η
+    mod.πA = πA
+    mod.πC = πC
+    mod.πG = πG
+    mod.πT = πT
+  end
+  return mod
+end
 
 function show(io::IO, object::GTRabs)
   print(io, "\r\e[0m\e[1mG\e[0meneralised \e[1mT\e[0mime \e[1mR\e[0meversible model (absolute rate form)

--- a/src/nucleic_acid/gtr/relative.jl
+++ b/src/nucleic_acid/gtr/relative.jl
@@ -1,4 +1,4 @@
-struct GTRrel <: GTR
+mutable struct GTRrel <: GTR
   α::Float64
   β::Float64
   γ::Float64
@@ -30,6 +30,59 @@ struct GTRrel <: GTR
   end
 end
 
+"""
+```julia-repl
+julia> model = GTR(0.3, 0.6, 0.6, 0.4, 0.4, 0.25, 0.25, 0.25, 0.25);
+
+julia> setrate!(model, [0.5, 0.5, 0.5, 0.5, 0.5, 0.25, 0.25, 0.25, 0.25])
+Generalised Time Reversible model (relative rate form)
+α = 0.5, β = 0.5, γ = 0.5, δ = 0.5, ϵ = 0.5, π = [0.25, 0.25, 0.25, 0.25]
+```
+"""
+@inline function setrate!(mod::GTRrel, rate::Vector{Float64})
+  #check length of vector
+  if length(rate) != 9
+    @error "GTR rate must be a vector of length 9"
+  else 
+      #separate vector into pieces
+    α = rate[1]
+    β = rate[2]
+    γ = rate[3]
+    δ = rate[4]
+    ϵ = rate[5]
+    πA = rate[6]
+    πC = rate[7]
+    πG = rate[8]
+    πT = rate[9]
+    #check correctness of rates (from above)
+    if α <= 0.
+      @error "GTR parameter α must be positive"
+    elseif β <= 0.
+      @error "GTR parameter β must be positive"
+    elseif γ <= 0.
+      @error "GTR parameter γ must be positive"
+    elseif δ <= 0.
+      @error "GTR parameter δ must be positive"
+    elseif ϵ <= 0.
+      @error "GTR parameter ϵ must be positive"
+    elseif sum([πA,πC,πG,πT]) != 1.0
+      @error "GTR frequencies must sum to 1.0"
+    elseif any([πA,πC,πG,πT] .<= 0.0)
+      @error "GTR frequencies must be positive"
+    end
+    #add rate
+    mod.α = α
+    mod.β = β
+    mod.γ = γ
+    mod.δ = δ
+    mod.ϵ = ϵ
+    mod.πA = πA
+    mod.πC = πC
+    mod.πG = πG
+    mod.πT = πT
+  end
+  return mod
+end
 
 function show(io::IO, object::GTRrel)
   print(io, "\r\e[0m\e[1mG\e[0meneralised \e[1mT\e[0mime \e[1mR\e[0meversible model (relative rate form)

--- a/src/nucleic_acid/hky85/absolute.jl
+++ b/src/nucleic_acid/hky85/absolute.jl
@@ -1,4 +1,4 @@
-struct HKY85abs <: HKY85
+mutable struct HKY85abs <: HKY85
   α::Float64
   β::Float64
   πA::Float64
@@ -20,6 +20,47 @@ struct HKY85abs <: HKY85
   end
 end
 
+"""
+```julia-repl
+julia> model = HKY85(0.6, 0.4, 0.25, 0.25, 0.25, 0.25);
+
+julia> setrate!(model, [0.5, 0.5, 0.25, 0.25, 0.25, 0.25])
+Hasegawa, Kishino, and Yano 1985 model (absolute rate form)
+α = 0.5, β = 0.5, π = [0.25, 0.25, 0.25, 0.25]
+```
+"""
+@inline function setrate!(mod::HKY85abs, rate::Vector{Float64})
+  #check length of vector
+  if length(rate) != 6
+    @error "HKY85 rate must be a vector of length 6"
+  else 
+    #separate vector into pieces
+    α = rate[1]
+    β = rate[2]
+    πA = rate[3]
+    πC = rate[4]
+    πG = rate[5]
+    πT = rate[6]
+    #check correctness of rates
+    if α <= 0.
+      @error "HKY85 parameter α must be positive"
+    elseif β <= 0.
+      @error "HKY85 parameter β must be positive"
+    elseif sum([πA,πC,πG,πT]) != 1.0
+      @error "HKY85 frequencies must sum to 1.0"
+    elseif any([πA,πC,πG,πT] .<= 0.0)
+      @error "HKY85 frequencies must be positive"
+    end
+    #add rates
+    mod.α = α
+    mod.β = β
+    mod.πA = πA
+    mod.πC = πC
+    mod.πG = πG
+    mod.πT = πT
+  end
+  return mod
+end
 
 function show(io::IO, object::HKY85abs)
   print(io, "\r\e[0m\e[1mH\e[0masegawa, \e[1mK\e[0mishino, and \e[1mY\e[0mano 19\e[1m85\e[0m model (absolute rate form)

--- a/src/nucleic_acid/hky85/relative.jl
+++ b/src/nucleic_acid/hky85/relative.jl
@@ -1,4 +1,4 @@
-struct HKY85rel <: HKY85
+mutable struct HKY85rel <: HKY85
   κ::Float64
   πA::Float64
   πC::Float64
@@ -15,6 +15,44 @@ struct HKY85rel <: HKY85
     end
     new(κ, πA, πC, πG, πT)
   end
+end
+
+"""
+```julia-repl
+julia> model = HKY85(0.6, 0.25, 0.25, 0.25, 0.25);
+
+julia> setrate!(model, [0.5, 0.25, 0.25, 0.25, 0.25])
+Hasegawa, Kishino, and Yano 1985 model (absolute rate form)
+κ = 0.5, π = [0.25, 0.25, 0.25, 0.25]
+```
+"""
+@inline function setrate!(mod::HKY85rel, rate::Vector{Float64})
+  #check length of vector
+  if length(rate) != 5
+    @error "HKY85 rate must be a vector of length 5"
+  else 
+    #separate vector into pieces
+    κ = rate[1]
+    πA = rate[2]
+    πC = rate[3]
+    πG = rate[4]
+    πT = rate[5]
+    #check correctness of rates (from above)
+    if κ <= 0.
+      @error "HKY85 parameter κ must be positive"
+    elseif sum([πA,πC,πG,πT]) != 1.0
+      @error "HKY85 frequencies must sum to 1.0"
+    elseif any([πA,πC,πG,πT] .<=0.0)
+      @error "HKY85 frequencies must be positive"
+    end
+    #add rate
+    mod.κ = κ
+    mod.πA = πA
+    mod.πC = πC
+    mod.πG = πG
+    mod.πT = πT
+  end
+  return mod
 end
 
 

--- a/src/nucleic_acid/jc69/absolute.jl
+++ b/src/nucleic_acid/jc69/absolute.jl
@@ -1,4 +1,4 @@
-struct JC69abs <: JC69
+mutable struct JC69abs <: JC69
     λ::Float64
     function JC69abs(λ::Float64)
         if λ <= 0.
@@ -8,6 +8,31 @@ struct JC69abs <: JC69
     end
 end
 
+"""
+```julia-repl
+julia> model = JC69(1.0);
+
+julia> setrate!(model, [0.5])
+Jukes and Cantor 1969 model (absolute rate form)
+λ = 0.5
+```
+"""
+@inline function setrate!(mod::JC69abs, rate::Vector{Float64})
+    #check length of vector
+    if length(rate) != 1
+      @error "JC69 rate must be a vector of length 1"
+    else 
+      #separate vector into pieces
+      λ = rate[1]
+      #check correctness of rates (from above)
+      if λ <= 0.
+        @error "JC69 parameter λ must be positive"
+      end
+      #add rate
+      mod.λ = λ
+    end
+    return mod
+end
 
 function show(io::IO, object::JC69abs)
   print(io, "\r\e[0m\e[1mJ\e[0mukes and \e[1mC\e[0mantor 19\e[1m69\e[0m model (absolute rate form)

--- a/src/nucleic_acid/jc69/relative.jl
+++ b/src/nucleic_acid/jc69/relative.jl
@@ -1,13 +1,29 @@
-struct JC69rel <: JC69 end
+mutable struct JC69rel <: JC69 end
 
 
 function show(io::IO, object::JC69rel)
-  print(io, "\r\e[0m\e[1mJ\e[0mukes and \e[1mC\e[0mantor 19\e[1m69\e[0m model (relative rate form)")
+  print(io, "\r\e[0m\e[1mJ\e[0mukes and \e[1mC\e[0mantor 19\e[1m69\e[0m model 
+  (relative rate form)")
 end
 
 
 JC69() = JC69rel()
 
+"""
+Jukes and Cantor 1969 relative has no rate.
+
+```julia-repl
+julia> model = JC69();
+
+julia> setrate!(model)
+Jukes and Cantor 1969 model
+  (relative rate form)
+```
+"""
+@inline function setrate!(mod::JC69rel)
+  #nothing to do here. This function is needed to avoid an error.
+  return mod
+end
 
 @inline function Q(mod::JC69rel)
   Q₁ =  0.25

--- a/src/nucleic_acid/k80/absolute.jl
+++ b/src/nucleic_acid/k80/absolute.jl
@@ -1,4 +1,4 @@
-struct K80abs <: K80
+mutable struct K80abs <: K80
   α::Float64
   β::Float64
   function K80abs(α::Float64, β::Float64)
@@ -9,6 +9,35 @@ struct K80abs <: K80
     end
     new(α, β)
   end
+end
+
+"""
+```julia-repl
+julia> model = K80(0.6, 0.6);
+
+julia> setrate!(model, [0.5, 0.5])
+Kimura 1980 model (absolute rate form)
+α = 0.5, β = 0.5
+```
+"""
+@inline function setrate!(mod::K80abs, rate::Vector{Float64})
+  #check length of vector
+  if length(rate) != 2
+    @error "K80 rate must be a vector of length 2"
+  else 
+    #separate vector into pieces
+    α = rate[1]
+    β = rate[2]
+    if α <= 0.
+      @error "K80 parameter α must be positive"
+    elseif β <= 0.
+      @error "K80 parameter β must be positive"
+    end
+    #set new rate
+    mod.α = α
+    mod.β = β
+  end
+  return mod
 end
 
 

--- a/src/nucleic_acid/k80/relative.jl
+++ b/src/nucleic_acid/k80/relative.jl
@@ -1,4 +1,4 @@
-struct K80rel <: K80
+mutable struct K80rel <: K80
   κ::Float64
   function K80rel(κ::Float64)
     if κ <= 0.
@@ -8,6 +8,31 @@ struct K80rel <: K80
   end
 end
 
+"""
+```julia-repl
+julia> model = K80(0.6);
+
+julia> setrate!(model, [0.5])
+Kimura 1980 model (relative rate form)
+κ = 0.5
+```
+"""
+@inline function setrate!(mod::K80rel, rate::Vector{Float64})
+  #check length of vector
+  if length(rate) != 1
+    @error "K80 rate must be a vector of length 1"
+  else 
+    #separate vector into pieces
+    κ = rate[1]
+    #check correctness of rates (from above)
+    if κ <= 0.
+      @error "K80 parameter κ must be positive"
+    end
+    #add rate
+    mod.κ = κ
+  end
+  return mod
+end
 
 function show(io::IO, object::K80rel)
   print(io, "\r\e[0m\e[1mK\e[0mimura 19\e[1m80\e[0m model (relative rate form)

--- a/src/nucleic_acid/nucleic_acid.jl
+++ b/src/nucleic_acid/nucleic_acid.jl
@@ -15,6 +15,19 @@ _πY(mod::NASM) = _πT(mod) + _πC(mod)
 
 
 """
+    setrate!(mod::NucleicAcidSubstitutionModel, rate::Vector{Float64})
+
+Modify the rates of a `NucleicAcidSubstitutionModel`. If vector is incorrect length 
+or parameters incorrectly specified, provide error messages. Examples given for each.
+
+"""
+@inline function setrate!(mod::NASM)
+    @error "setrate not defined for $(typeof(mod))."
+end
+
+
+
+"""
 Generate a Q matrix for a `NucleicAcidSubstitutionModel`, of the form:
 
 \$Q = \\begin{bmatrix}

--- a/src/nucleic_acid/tn93/absolute.jl
+++ b/src/nucleic_acid/tn93/absolute.jl
@@ -1,4 +1,4 @@
-struct TN93abs <: TN93
+mutable struct TN93abs <: TN93
   α1::Float64
   α2::Float64
   β::Float64
@@ -23,6 +23,51 @@ struct TN93abs <: TN93
   end
 end
 
+"""
+```julia-repl
+julia> model = TN93(0.4, 0.6, 0.6, 0.25, 0.25, 0.25, 0.25);
+
+julia> setrate!(model, [0.5, 0.5, 0.5, 0.25, 0.25, 0.25, 0.25])
+Tamura and Nei 1993 model (absolute rate form)
+α1 = 0.5, α2 = 0.5, β = 0.5, π = [0.25, 0.25, 0.25, 0.25]
+```
+"""
+@inline function setrate!(mod::TN93abs, rate::Vector{Float64})
+  #check length of vector
+  if length(rate) != 7
+  @error "TN93 rate must be a vector of length 7"
+  else 
+    #separate vector into pieces
+    α1 = rate[1]
+    α2 = rate[2]
+    β = rate[3]
+    πA = rate[4]
+    πC = rate[5]
+    πG = rate[6]
+    πT = rate[7]
+    #check correctness of rates
+    if α1 <= 0.
+      @error "TN93 parameter α1 must be positive"
+    elseif α2 <= 0.
+      @error "TN93 parameter α2 must be positive"
+    elseif β <= 0.
+      @error "TN93 parameter β must be positive"
+    elseif sum([πA, πC, πG, πT]) != 1.0
+      @error "TN93 frequencies must sum to 1.0"
+    elseif any([πA, πC, πG, πT] .<= 0.0)
+      @error "TN93 frequencies must be positive"
+    end
+    #add rates
+    mod.α1 = α1
+    mod.α2 = α2
+    mod.β = β
+    mod.πA = πA
+    mod.πC = πC
+    mod.πG = πG
+    mod.πT = πT
+  end
+  return mod
+end
 
 function show(io::IO, object::TN93abs)
   print(io, "\r\e[0m\e[1mT\e[0mamura and \e[1mN\e[0mei 19\e[1m93\e[0m model (absolute rate form)

--- a/src/nucleic_acid/tn93/relative.jl
+++ b/src/nucleic_acid/tn93/relative.jl
@@ -1,4 +1,4 @@
-struct TN93rel <: TN93
+mutable struct TN93rel <: TN93
   κ1::Float64
   κ2::Float64
   πA::Float64
@@ -18,6 +18,48 @@ struct TN93rel <: TN93
     end
     new(κ1, κ2, πA, πC, πG, πT)
   end
+end
+
+"""
+```julia-repl
+julia> model = TN93(0.6, 0.6, 0.25, 0.25, 0.25, 0.25);
+
+julia> setrate!(model, [0.5, 0.5, 0.25, 0.25, 0.25, 0.25])
+Tamura and Nei 1993 model (relative rate form)
+κ1 = 0.5, κ2 = 0.5, π = [0.25, 0.25, 0.25, 0.25]
+```
+"""
+@inline function setrate!(mod::TN93rel, rate::Vector{Float64})
+  #check length of vector
+  if length(rate) != 6
+  @error "TN93 rate must be a vector of length 6"
+  else 
+    #separate vector into pieces
+    κ1 = rate[1]
+    κ2 = rate[2]
+    πA = rate[3]
+    πC = rate[4]
+    πG = rate[5]
+    πT = rate[6]
+    #check correctness of rates (from above)
+    if κ1 <= 0.
+      @error "TN93 parameter κ1 must be positive"
+    elseif κ2 <= 0.
+      @error "TN93 parameter κ2 must be positive"
+    elseif sum([πA, πC, πG, πT]) != 1.0
+      @error "TN93 frequencies must sum to 1.0"
+    elseif any([πA, πC, πG, πT] .<= 0.0)
+      @error "TN93 frequencies must be positive"
+    end
+  #add rate
+  mod.κ1 = κ1
+  mod.κ2 = κ2
+  mod.πA = πA
+  mod.πC = πC
+  mod.πG = πG
+  mod.πT = πT
+  end
+  return mod
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,7 +37,12 @@ end
   @test isapprox(diag(P(testmod2, 1.0e9)), _π(testmod2), atol = 1.0e-5)
   @test sum(_π(testmod1)) == 1.0
   @test sum(_π(testmod2)) == 1.0
+
+  setrate!(testmod1)
+  setrate!(testmod2, [.5])
+  @test testmod2.λ ≈ .5
 end
+
 
 
 @testset "K80" begin
@@ -51,6 +56,12 @@ end
   @test isapprox(diag(P(testmod2, 1.0e9)), _π(testmod2), atol = 1.0e-5)
   @test sum(_π(testmod1)) == 1.0
   @test sum(_π(testmod2)) == 1.0
+
+  setrate!(testmod1, [0.6])
+  setrate!(testmod2, [0.5, 0.6])
+  @test testmod1.κ ≈ 0.6
+  @test testmod2.α ≈ 0.5
+  @test testmod2.β ≈ 0.6
 end
 
 
@@ -65,6 +76,18 @@ end
   @test isapprox(diag(P(testmod2, 1.0e9)), _π(testmod2), atol = 1.0e-5)
   @test sum(_π(testmod1)) == 1.0
   @test sum(_π(testmod2)) == 1.0
+
+  setrate!(testmod1, [0.2, 0.3, 0.25, 0.25])
+  setrate!(testmod2, [0.8, 0.2, 0.3, 0.25, 0.25])
+  @test testmod1.πA ≈ 0.2
+  @test testmod1.πC ≈ 0.3
+  @test testmod1.πG ≈ 0.25
+  @test testmod1.πT ≈ 0.25
+  @test testmod2.β ≈ 0.8
+  @test testmod2.πA ≈ 0.2
+  @test testmod2.πC ≈ 0.3
+  @test testmod2.πG ≈ 0.25
+  @test testmod2.πT ≈ 0.25
 end
 
 
@@ -79,6 +102,20 @@ end
   @test isapprox(diag(P(testmod2, 1.0e9)), _π(testmod2), atol = 1.0e-5)
   @test sum(_π(testmod1)) == 1.0
   @test sum(_π(testmod2)) == 1.0
+
+  setrate!(testmod1, [0.6, 0.2, 0.3, 0.25, 0.25])
+  setrate!(testmod2, [1.0, 0.8, 0.2, 0.3, 0.25, 0.25])
+  @test testmod1.κ ≈ 0.6
+  @test testmod1.πA ≈ 0.2
+  @test testmod1.πC ≈ 0.3
+  @test testmod1.πG ≈ 0.25
+  @test testmod1.πT ≈ 0.25
+  @test testmod2.κ ≈ 1.0
+  @test testmod2.β ≈ 0.8
+  @test testmod2.πA ≈ 0.2
+  @test testmod2.πC ≈ 0.3
+  @test testmod2.πG ≈ 0.25
+  @test testmod2.πT ≈ 0.25
 end
 
 
@@ -93,6 +130,20 @@ end
   @test isapprox(diag(P(testmod2, 1.0e9)), _π(testmod2), atol = 1.0e-5)
   @test sum(_π(testmod1)) == 1.0
   @test sum(_π(testmod2)) == 1.0
+
+  setrate!(testmod1, [0.8, 0.2, 0.3, 0.25, 0.25])
+  setrate!(testmod2, [0.8, 0.9, 0.2, 0.3, 0.25, 0.25])
+  @test testmod1.κ ≈ 0.8 
+  @test testmod1.πA ≈ 0.2
+  @test testmod1.πC ≈ 0.3
+  @test testmod1.πG ≈ 0.25
+  @test testmod1.πT ≈ 0.25
+  @test testmod2.α ≈ 0.8
+  @test testmod2.β ≈ 0.9
+  @test testmod2.πA ≈ 0.2
+  @test testmod2.πC ≈ 0.3
+  @test testmod2.πG ≈ 0.25
+  @test testmod2.πT ≈ 0.25
 end
 
 
@@ -107,6 +158,22 @@ end
   @test isapprox(diag(P(testmod2, 1.0e9)), _π(testmod2), atol = 1.0e-5)
   @test sum(_π(testmod1)) == 1.0
   @test sum(_π(testmod2)) == 1.0
+
+  setrate!(testmod1, [0.5, 0.6, 0.2, 0.3, 0.25, 0.25])
+  setrate!(testmod2, [0.8, 0.6, 0.9, 0.2, 0.3, 0.25, 0.25])
+  @test testmod1.κ1 ≈ 0.5
+  @test testmod1.κ2 ≈ 0.6
+  @test testmod1.πA ≈ 0.2
+  @test testmod1.πC ≈ 0.3
+  @test testmod1.πG ≈ 0.25
+  @test testmod1.πT ≈ 0.25
+  @test testmod2.α1 ≈ 0.8
+  @test testmod2.α2 ≈ 0.6
+  @test testmod2.β ≈ 0.9
+  @test testmod2.πA ≈ 0.2
+  @test testmod2.πC ≈ 0.3
+  @test testmod2.πG ≈ 0.25
+  @test testmod2.πT ≈ 0.25
 end
 
 
@@ -121,6 +188,28 @@ end
   @test isapprox(diag(P(testmod2, 1.0e9)), _π(testmod2), atol = 1.0e-5)
   @test sum(_π(testmod1)) == 1.0
   @test sum(_π(testmod2)) == 1.0
+
+  setrate!(testmod1, [0.5, 0.6, 0.7, 0.8, 0.9, 0.2, 0.3, 0.25, 0.25])
+  setrate!(testmod2, [0.8, 0.5, 0.6, 0.7, 0.8, 0.9, 0.2, 0.3, 0.25, 0.25])
+  @test testmod1.α ≈ 0.5
+  @test testmod1.β ≈ 0.6
+  @test testmod1.γ ≈ 0.7
+  @test testmod1.δ ≈ 0.8
+  @test testmod1.ϵ ≈ 0.9
+  @test testmod1.πA ≈ 0.2
+  @test testmod1.πC ≈ 0.3
+  @test testmod1.πG ≈ 0.25
+  @test testmod1.πT ≈ 0.25
+  @test testmod2.α ≈ 0.8
+  @test testmod2.β ≈ 0.5
+  @test testmod2.γ ≈ 0.6
+  @test testmod2.δ ≈ 0.7
+  @test testmod2.ϵ ≈ 0.8
+  @test testmod2.η ≈ 0.9
+  @test testmod2.πA ≈ 0.2
+  @test testmod2.πC ≈ 0.3
+  @test testmod2.πG ≈ 0.25
+  @test testmod2.πT ≈ 0.25
 end
 
 @testset "Indexing" begin


### PR DESCRIPTION
# Mutable NucleicAcidSubstitutionModels
## Types of changes
This PR implements the following changes:
* [x] :sparkles: New feature
* [ ] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail
Modifies all the NucleicAcidSubstitutionModels to allow them to be mutable with new function, setrate!.

We need the models to be mutable because we want to use this package in another package that will optimize model rates based on data.

```julia-repl
julia>  model = K80(0.5, 1.0);

julia> setrate!(model, [.5, .5])
Kimura 1980 model (absolute rate form)
α = 0.5, β = 0.5
```

## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
- [x] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/stable/manual/documentation/).
- [x] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [x] :ok: There are unit tests that cover the code changes I have made.
- [x] :ok: The unit tests cover my code changes AND they pass.
- [ ] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
I couldn't find this CHANGELOG.md file or a template, but I'd be happy to create one if you point me in the right direction.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [x] :thought_balloon: I have commented liberally for any complex pieces of internal code.