### PR TITLE
Fix eigen

### DIFF
--- a/src/nucleic_acid/jc69/absolute.jl
+++ b/src/nucleic_acid/jc69/absolute.jl
@@ -36,7 +36,7 @@ function P(mod::JC69abs, t::Float64)
   λ = mod.λ
   ω = exp(-t * λ)
   P₁ = 0.25 + 0.75 * ω
-  P₂ = 0.25 + 0.25 * ω
+  P₂ = 0.25 - 0.25 * ω
   return Pmatrix(P₁, P₂, P₂, P₂,
                  P₂, P₁, P₂, P₂,
                  P₂, P₂, P₁, P₂,

--- a/src/nucleic_acid/jc69/relative.jl
+++ b/src/nucleic_acid/jc69/relative.jl
@@ -25,7 +25,7 @@ end
   end
   e₁ = exp(-t)
   P₁ = 0.25 + 0.75 * e₁
-  P₂ = 0.25 + 0.25 * e₁
+  P₂ = 0.25 - 0.25 * e₁
   return Pmatrix(P₁, P₂, P₂, P₂,
                  P₂, P₁, P₂, P₂,
                  P₂, P₂, P₁, P₂,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -117,6 +117,10 @@ end
   @test Q(testmod1) == Q(testmod2)
   @test P(testmod1, 1.0e2) ≈ P_generic(testmod1, 1.0e2)
   @test P(testmod2, 1.0e2) ≈ P_generic(testmod2, 1.0e2)
+  @test P(testmod1, [1.0 2.0])[1] ≈ P_generic(testmod1, 1.0)
+  @test P(testmod2, [1.0 2.0])[1] ≈ P_generic(testmod2, 1.0)
+  @test P(testmod1, [1.0 2.0])[2] ≈ P_generic(testmod1, 2.0)
+  @test P(testmod2, [1.0 2.0])[2] ≈ P_generic(testmod2, 2.0)
   @test isapprox(diag(P(testmod1, 1.0e9)), _π(testmod1), atol = 1.0e-5)
   @test isapprox(diag(P(testmod2, 1.0e9)), _π(testmod2), atol = 1.0e-5)
   @test sum(_π(testmod1)) == 1.0


### PR DESCRIPTION
Julia v1 update: Updates P_generic to use `eigen` instead of `eig` for eigenvalue decomposition

## Types of changes

This PR implements the following changes:
_(Please tick any or all of the following that are applicable)_

* [ ] :sparkles: New feature (A non-breaking change which adds functionality).
* [x] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

- If you have implemented new features or behaviour
  - **Provide a description of the addition** in as many details as possible.
    AFAIK `eig` has been removed from Julia v1 in favour of `eigen`. I updated the P_generic function to use `eigen` to compute the eigenvalue decomposition of Q. I also altered the function to preferentially call `eigen` on a symmetrical matrix, as this is likely to be more efficient. The changes are covered by new unit tests.
    This pull request also includes a fix to a typo in the Jukes Cantor model that resulted in probabilities being calculated incorrectly.

  - **Provide justification of the addition**.
    The P_generic function was unusable in its current state.

  - **Provide a runnable example of use of your addition**.

        using SubstitutionModels
        gtr = GTRabs(6.,5.,4.,3.,2.,1.,0.1,0.2,0.3,0.4)
        P(gtr, [1.0])   # Previously ERROR: UndefVarError: eig not defined
        # >1-element Array{StaticArrays.SArray{Tuple{4,4},Float64,2,16},1}: [0.140646 0.197744 0.25993...
