### PR TITLE
Constructor consistency/documentation fix

### DIFF
--- a/.github/workflows/test-lts.yml
+++ b/.github/workflows/test-lts.yml
@@ -1,0 +1,34 @@
+name: julia-1.0
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        julia-version: ['1.0']
+        julia-arch: [x64]
+        os: [ubuntu-latest, macOS-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.julia-version }}
+          arch: ${{ matrix.julia-arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          depwarn: no

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -1,0 +1,34 @@
+name: julia-nightly
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        julia-version: ['nightly']
+        julia-arch: [x64]
+        os: [ubuntu-latest, macOS-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.julia-version }}
+          arch: ${{ matrix.julia-arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          depwarn: no

--- a/.github/workflows/test-stable.yml
+++ b/.github/workflows/test-stable.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: julia-1.6
 
 on: [push, pull_request]
 
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1.0', '1']
+        julia-version: ['1.6']
         julia-arch: [x64]
         os: [ubuntu-latest, macOS-latest]
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SubstitutionModels"
 uuid = "8365b1bb-bd83-58ee-a267-f2965fc81c73"
 authors = ["Justin Angevaare <justinangevaare@gmail.com>"]
-version = "0.4.2"
+version = "0.5.0"
 
 [deps]
 BioSymbols = "3c28c6f8-a34d-59c4-9654-267d177fcfa9"
@@ -11,7 +11,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [compat]
 BioSymbols = "3, 4, 5"
 StaticArrays = "0.12, 1"
-julia = "1"
+julia = "1.0, 1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
 
 **Development status:**
 
-[![CI-stable](https://github.com/BioJulia/SubstitutionModels.jl/actions/workflows/ci-stable.yml/badge.svg)](https://github.com/BioJulia/SubstitutionModels.jl/actions/workflows/ci-stable.yml)
+[![test-lts](https://github.com/BioJulia/SubstitutionModels.jl/actions/workflows/test-lts.yml/badge.svg)](https://github.com/BioJulia/SubstitutionModels.jl/actions/workflows/test-lts.yml)
+[![test-stable](https://github.com/BioJulia/SubstitutionModels.jl/actions/workflows/test-stable.yml/badge.svg)](https://github.com/BioJulia/SubstitutionModels.jl/actions/workflows/test-stable.yml)
+[![test-nightly](https://github.com/BioJulia/SubstitutionModels.jl/actions/workflows/test-nightly.yml/badge.svg)](https://github.com/BioJulia/SubstitutionModels.jl/actions/workflows/test-nightly.yml)
 [![codecov.io](http://codecov.io/github/BioJulia/SubstitutionModels.jl/coverage.svg?branch=master)](http://codecov.io/github/BioJulia/SubstitutionModels.jl?branch=master)
 [![](https://img.shields.io/badge/docs-latest-blue.svg)](https://BioJulia.github.io/SubstitutionModels.jl/latest)
 
@@ -30,8 +32,8 @@ The current release version can be installed
 from the Julia REPL:
 
 ```julia
-julia> using Pkg
-julia> add("SubstitutionModels")
+using Pkg
+Pkg.add("SubstitutionModels")
 ```
 
 ## Contributing and Questions

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+build/
+site/

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,2 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-
-[compat]
-Documenter = "~0.22"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,9 +1,10 @@
-using Documenter, SubstitutionModels
+using Documenter
+using SubstitutionModels
 
 makedocs(
-    modules = [SubstitutionModels],
+    sitename = "SubstitutionModels",
     format = Documenter.HTML(),
-    sitename = "SubstitutionModels.jl",
+    modules = [SubstitutionModels],
     pages = [
         "Home" => "index.md",
         "Manual" => [
@@ -17,5 +18,6 @@ makedocs(
 )
 
 deploydocs(
-    repo = "github.com/BioJulia/SubstitutionModels.jl.git"
+    repo = "github.com/BioJulia/SubstitutionModels.jl.git",
+    push_preview = true
 )

--- a/docs/src/man/models.md
+++ b/docs/src/man/models.md
@@ -1,9 +1,3 @@
-```@meta
-DocTestSetup = quote
-  using SubstitutionModels
-end
-```
-
 # SubstitutionModels.jl
 
 ## What are subsitution models?

--- a/docs/src/man/models.md
+++ b/docs/src/man/models.md
@@ -1,3 +1,9 @@
+```@meta
+DocTestSetup = quote
+  using SubstitutionModels
+end
+```
+
 # SubstitutionModels.jl
 
 ## What are subsitution models?

--- a/docs/src/man/modeltypes.md
+++ b/docs/src/man/modeltypes.md
@@ -1,3 +1,9 @@
+```@meta
+DocTestSetup = quote
+  using SubstitutionModels
+end
+```
+
 # Nucleic Acid Substitution Models
 
 ## Included Substitution Models
@@ -20,17 +26,19 @@ The most basic construction method detects whether the absolute or relative rate
 K80(1e-2)
 
 # output
-Kimura 1980 model (relative rate form)
+
+[0m[1mK[0mimura 19[1m80[0m model (relative rate form)
 κ = 0.01
 ```
 
 Substitution model construction involves a number of checks for parameter validity, though these may be optionally bypassed:
 
 ```jldoctest
-K80(-1e-2, false)
+K80(-1e-2, safe=false)
 
 # output
-Kimura 1980 model (relative rate form)
+
+[0m[1mK[0mimura 19[1m80[0m model (relative rate form)
 κ = -0.01
 ```
 
@@ -47,7 +55,8 @@ K80rel<:K80, K80abs<:K80
 K80abs(1e-2, 1.5e-2)
 
 # output
-Kimura 1980 model (absolute rate form)
+
+[0m[1mK[0mimura 19[1m80[0m model (absolute rate form)
 α = 0.01, β = 0.015
 ```
 
@@ -64,7 +73,8 @@ fieldnames(F81abs)
 F81abs(1e-2, 0.2475, 0.2425, 0.2575, 0.2525)
 
 # output
-Felsenstein 1981 model (absolute rate form)
+
+[0m[1mF[0melsenstein 19[1m81[0m model (absolute rate form)
 β = 0.01, π = [0.2475, 0.2425, 0.2575, 0.2525]
 ```
 
@@ -77,17 +87,19 @@ For models that support different base frequencies, a parameter vector and a bas
 F81abs([1e-2], [0.2475, 0.2425, 0.2575, 0.2525])
 
 # output
-Felsenstein 1981 model (absolute rate form)
+
+[0m[1mF[0melsenstein 19[1m81[0m model (absolute rate form)
 β = 0.01, π = [0.2475, 0.2425, 0.2575, 0.2525]
 ```
 
 The unsafe construction method is still available, as is auto-detection of absolute or relative rate types of substitution models.
 
 ```jldoctest
-K80([1e-2, 1.5e-2], true)
+K80([1e-2, 1.5e-2], safe = true)
 
 # output
-Kimura 1980 model (absolute rate form)
+
+[0m[1mK[0mimura 19[1m80[0m model (absolute rate form)
 α = 0.01, β = 0.015
 ```
 
@@ -95,10 +107,11 @@ Kimura 1980 model (absolute rate form)
 Lastly, `convert` methods are also provided for each substitution model type:
 
 ```jldoctest
-convert(K80, [1e-2, 1.5e-2], true)
+convert(K80, [1e-2, 1.5e-2])
 
 # output
-Kimura 1980 model (absolute rate form)
+
+[0m[1mK[0mimura 19[1m80[0m model (absolute rate form)
 α = 0.01, β = 0.015
 ```
 

--- a/docs/src/man/modeltypes.md
+++ b/docs/src/man/modeltypes.md
@@ -1,7 +1,5 @@
-```@meta
-DocTestSetup = quote
-  using SubstitutionModels
-end
+```@setup sm
+using SubstitutionModels
 ```
 
 # Nucleic Acid Substitution Models
@@ -22,60 +20,34 @@ For the convenience of the user, several construction methods exist for each sub
 
 ### Method 1
 The most basic construction method detects whether the absolute or relative rate form of a substitution model is being referenced based on the number of parameters, and constructs it:
-```jldoctest
+```@repl sm
 K80(1e-2)
-
-# output
-
-[0m[1mK[0mimura 19[1m80[0m model (relative rate form)
-κ = 0.01
 ```
 
 Substitution model construction involves a number of checks for parameter validity, though these may be optionally bypassed:
 
-```jldoctest
+```@repl sm
 K80(-1e-2, safe=false)
-
-# output
-
-[0m[1mK[0mimura 19[1m80[0m model (relative rate form)
-κ = -0.01
 ```
 
 The exact model type may be specific as well, to avoid the software detection of absolute or relative rate specification. The specific forms are the parent models' name followed by `abs` for absolute or `rel` for relative rate form.
 
-```jldoctest
+```@repl sm
 K80rel<:K80, K80abs<:K80
-
-# output
-(true, true)
 ```
 
-```jldoctest
+```@repl sm
 K80abs(1e-2, 1.5e-2)
-
-# output
-
-[0m[1mK[0mimura 19[1m80[0m model (absolute rate form)
-α = 0.01, β = 0.015
 ```
 
 For models requiring specification of base frequencies, those can be provided in the same manner as the other model parameters:
 
-```jldoctest
+```@repl sm
 fieldnames(F81abs)
-
-# output
-(:β, :πA, :πC, :πG, :πT)
 ```
 
-```jldoctest
+```@repl sm
 F81abs(1e-2, 0.2475, 0.2425, 0.2575, 0.2525)
-
-# output
-
-[0m[1mF[0melsenstein 19[1m81[0m model (absolute rate form)
-β = 0.01, π = [0.2475, 0.2425, 0.2575, 0.2525]
 ```
 
 ### Method 2
@@ -83,36 +55,21 @@ It may be familar or convenient for some SubstitutionModels.jl users to construc
 This is also a supported construction method. When specifying a model with an equal base frequency, a single parameter vector is required for construction.
 For models that support different base frequencies, a parameter vector and a base frequency vector are both required.
 
-```jldoctest
+```@repl sm
 F81abs([1e-2], [0.2475, 0.2425, 0.2575, 0.2525])
-
-# output
-
-[0m[1mF[0melsenstein 19[1m81[0m model (absolute rate form)
-β = 0.01, π = [0.2475, 0.2425, 0.2575, 0.2525]
 ```
 
 The unsafe construction method is still available, as is auto-detection of absolute or relative rate types of substitution models.
 
-```jldoctest
+```@repl sm
 K80([1e-2, 1.5e-2], safe = true)
-
-# output
-
-[0m[1mK[0mimura 19[1m80[0m model (absolute rate form)
-α = 0.01, β = 0.015
 ```
 
 ### Method 3
 Lastly, `convert` methods are also provided for each substitution model type:
 
-```jldoctest
+```@repl sm
 convert(K80, [1e-2, 1.5e-2])
-
-# output
-
-[0m[1mK[0mimura 19[1m80[0m model (absolute rate form)
-α = 0.01, β = 0.015
 ```
 
 ## User defined substitution models

--- a/docs/src/man/pqmatrices.md
+++ b/docs/src/man/pqmatrices.md
@@ -1,9 +1,3 @@
-```@meta
-DocTestSetup = quote
-  using SubstitutionModels
-end
-```
-
 # Q and P Matrices
 
 Evolutionary analyses of sequences are conducted on a wide variety of time scales.

--- a/docs/src/man/pqmatrices.md
+++ b/docs/src/man/pqmatrices.md
@@ -1,3 +1,9 @@
+```@meta
+DocTestSetup = quote
+  using SubstitutionModels
+end
+```
+
 # Q and P Matrices
 
 Evolutionary analyses of sequences are conducted on a wide variety of time scales.

--- a/src/core.jl
+++ b/src/core.jl
@@ -22,15 +22,15 @@ const Pmatrix = SMatrix{4, 4, Float64}
 
 
 function Base.convert(::Type{T}, θ::F...; safe::Bool=true) where {T <: NASM, F <: Float64}
-  return T(θ..., safe)
+  return T(θ..., safe=safe)
 end
 
 
 function Base.convert(::Type{T}, θ_vec::A; safe::Bool=true) where {T <: NASM, A <: AbstractArray}
-  return T(θ_vec, safe)
+  return T(θ_vec, safe=safe)
 end
 
 
 function Base.convert(::Type{T}, θ_vec::A, π_vec::A; safe::Bool=true) where {T <: NASM, A <: AbstractArray}
-  return T(θ_vec, π_vec, safe)
+  return T(θ_vec, π_vec, safe=safe)
 end

--- a/src/nucleic_acid/f81/absolute.jl
+++ b/src/nucleic_acid/f81/absolute.jl
@@ -5,7 +5,7 @@ struct F81abs <: F81
   πG::Float64
   πT::Float64
   function F81abs(β::Float64,
-                  πA::Float64, πC::Float64, πG::Float64, πT::Float64,
+                  πA::Float64, πC::Float64, πG::Float64, πT::Float64;
                   safe::Bool=true)
     if safe
       if β <= 0.

--- a/src/nucleic_acid/f81/outer_constructors.jl
+++ b/src/nucleic_acid/f81/outer_constructors.jl
@@ -1,27 +1,27 @@
-F81(πA::F, πC::F, πG::F, πT::F,
+F81(πA::F, πC::F, πG::F, πT::F;
     safe::Bool=true) where F <: Float64 =
 F81rel(πA, πC, πG, πT)
 
 
 F81(β::F,
-    πA::F, πC::F, πG::F, πT::F,
+    πA::F, πC::F, πG::F, πT::F;
     safe::Bool=true) where F <: Float64 =
-F81abs(β, πA, πC, πG, πT, safe)
+F81abs(β, πA, πC, πG, πT, safe=safe)
 
 
 function F81(θ_vec::A,
-             π_vec::A,
+             π_vec::A;
              safe::Bool=true) where A <: AbstractArray
   if safe && length(π_vec) != 4
     error("Incorrect base frequency vector length")
   end
   if length(θ_vec) == 0
     return F81rel(π_vec[DNA_A], π_vec[DNA_C], π_vec[DNA_G], π_vec[DNA_T],
-                  safe)
+                  safe=safe)
   elseif length(θ_vec) == 1
     return F81abs(θ_vec[1],
                   π_vec[DNA_A], π_vec[DNA_C], π_vec[DNA_G], π_vec[DNA_T],
-                  safe)
+                  safe = safe)
   else
     error("Parameter vector length incompatiable with absolute or relative rate form of substitution model")
   end
@@ -29,7 +29,7 @@ end
 
 
 function F81rel(θ_vec::A,
-                π_vec::A,
+                π_vec::A;
                 safe::Bool=true) where A <: AbstractArray
   if safe
     if length(θ_vec) != 0
@@ -38,13 +38,13 @@ function F81rel(θ_vec::A,
       error("Incorrect base frequency vector length")
     end
   end
-  return F81rel(π_vec[DNA_A], π_vec[DNA_C], π_vec[DNA_G], π_vec[DNA_T], safe)
+  return F81rel(π_vec[DNA_A], π_vec[DNA_C], π_vec[DNA_G], π_vec[DNA_T], safe=safe)
 end
 
 
 
 function F81abs(θ_vec::A,
-                π_vec::A,
+                π_vec::A;
                 safe::Bool=true) where A <: AbstractArray
   if safe
     if length(θ_vec) != 1
@@ -53,5 +53,5 @@ function F81abs(θ_vec::A,
       error("Incorrect base frequency vector length")
     end
   end
-  return F81abs(θ_vec[1], π_vec[DNA_A], π_vec[DNA_C], π_vec[DNA_G], π_vec[DNA_T], safe)
+  return F81abs(θ_vec[1], π_vec[DNA_A], π_vec[DNA_C], π_vec[DNA_G], π_vec[DNA_T], safe=safe)
 end

--- a/src/nucleic_acid/f81/relative.jl
+++ b/src/nucleic_acid/f81/relative.jl
@@ -3,7 +3,7 @@ struct F81rel <: F81
   πC::Float64
   πG::Float64
   πT::Float64
-  function F81rel(πA::Float64, πC::Float64, πG::Float64, πT::Float64,
+  function F81rel(πA::Float64, πC::Float64, πG::Float64, πT::Float64;
                   safe::Bool=true)
     if safe
       if sum([πA,πC,πG,πT]) != 1.0

--- a/src/nucleic_acid/f84/absolute.jl
+++ b/src/nucleic_acid/f84/absolute.jl
@@ -6,7 +6,7 @@ struct F84abs <: F84
   πG::Float64
   πT::Float64
   function F84abs(κ::Float64, β::Float64,
-                  πA::Float64, πC::Float64, πG::Float64, πT::Float64,
+                  πA::Float64, πC::Float64, πG::Float64, πT::Float64;
                   safe::Bool=true)
     if safe
       if κ <= 0.

--- a/src/nucleic_acid/f84/outer_constructors.jl
+++ b/src/nucleic_acid/f84/outer_constructors.jl
@@ -1,17 +1,17 @@
 F84(κ::F,
-    πA::F, πC::F, πG::F, πT::F,
+    πA::F, πC::F, πG::F, πT::F;
     safe::Bool=true) where F <: Float64 =
-  F84rel(κ, πA, πC, πG, πT, safe)
+  F84rel(κ, πA, πC, πG, πT, safe=safe)
 
 
 F84(κ::F, β::F,
-    πA::F, πC::F, πG::F, πT::F,
+    πA::F, πC::F, πG::F, πT::F;
     safe::Bool=true) where F <: Float64 =
-  F84abs(κ, β, πA, πC, πG, πT, safe)
+  F84abs(κ, β, πA, πC, πG, πT, safe=safe)
 
 
 function F84(θ_vec::A,
-             π_vec::A,
+             π_vec::A;
              safe::Bool=true) where A <: AbstractArray
   if safe && length(π_vec) != 4
     error("Incorrect base frequency vector length")
@@ -19,11 +19,11 @@ function F84(θ_vec::A,
   if length(θ_vec) == 1
     return F84rel(θ_vec[1],
                   π_vec[DNA_A], π_vec[DNA_C], π_vec[DNA_G], π_vec[DNA_T],
-                  safe)
+                  safe=safe)
   elseif length(θ_vec) == 2
     return F84abs(θ_vec[1], θ_vec[2],
                   π_vec[DNA_A], π_vec[DNA_C], π_vec[DNA_G], π_vec[DNA_T],
-                  safe)
+                  safe=safe)
   else
     error("Parameter vector length incompatiable with absolute or relative rate form of substitution model")
   end
@@ -31,7 +31,7 @@ end
 
 
 function F84rel(θ_vec::A,
-                π_vec::A,
+                π_vec::A;
                 safe::Bool=true) where A <: AbstractArray
   if safe
     if length(θ_vec) != 1
@@ -40,12 +40,12 @@ function F84rel(θ_vec::A,
       error("Incorrect base frequency vector length")
     end
   end
-  return F84rel(θ_vec[1], π_vec[DNA_A], π_vec[DNA_C], π_vec[DNA_G], π_vec[DNA_T], safe)
+  return F84rel(θ_vec[1], π_vec[DNA_A], π_vec[DNA_C], π_vec[DNA_G], π_vec[DNA_T], safe=safe)
 end
 
 
 function F84abs(θ_vec::A,
-                π_vec::A,
+                π_vec::A;
                 safe::Bool=true) where A <: AbstractArray
   if safe
     if length(θ_vec) != 2
@@ -54,5 +54,5 @@ function F84abs(θ_vec::A,
       error("Incorrect base frequency vector length")
     end
   end
-  return F84abs(θ_vec[1], θ_vec[2], π_vec[DNA_A], π_vec[DNA_C], π_vec[DNA_G], π_vec[DNA_T], safe)
+  return F84abs(θ_vec[1], θ_vec[2], π_vec[DNA_A], π_vec[DNA_C], π_vec[DNA_G], π_vec[DNA_T], safe=safe)
 end

--- a/src/nucleic_acid/f84/relative.jl
+++ b/src/nucleic_acid/f84/relative.jl
@@ -5,7 +5,7 @@ struct F84rel <: F84
   πG::Float64
   πT::Float64
   function F84rel(κ::Float64,
-                  πA::Float64, πC::Float64, πG::Float64, πT::Float64,
+                  πA::Float64, πC::Float64, πG::Float64, πT::Float64;
                   safe::Bool=true)
     if safe
       if κ <= 0.

--- a/src/nucleic_acid/gtr/absolute.jl
+++ b/src/nucleic_acid/gtr/absolute.jl
@@ -11,7 +11,7 @@ struct GTRabs <: GTR
   πT::Float64
   function GTRabs(α::Float64, β::Float64, γ::Float64,
                   δ::Float64, ϵ::Float64, η::Float64,
-                  πA::Float64, πC::Float64, πG::Float64, πT::Float64,
+                  πA::Float64, πC::Float64, πG::Float64, πT::Float64;
                   safe::Bool=true)
     if safe
       if α <= 0.

--- a/src/nucleic_acid/gtr/outer_constructors.jl
+++ b/src/nucleic_acid/gtr/outer_constructors.jl
@@ -1,17 +1,17 @@
 GTR(α::F, β::F, γ::F, δ::F, ϵ::F, η::F,
-    πA::F, πC::F, πG::F, πT::F,
+    πA::F, πC::F, πG::F, πT::F;
     safe::Bool=true) where F <: Float64 =
-  GTRabs(α, β, γ, δ, ϵ, η, πA, πC, πG, πT, safe)
+  GTRabs(α, β, γ, δ, ϵ, η, πA, πC, πG, πT, safe=safe)
 
 
 GTR(α::F, β::F, γ::F, δ::F, ϵ::F,
-    πA::F, πC::F, πG::F, πT::F,
+    πA::F, πC::F, πG::F, πT::F;
     safe::Bool=true) where F <: Float64 =
-  GTRrel(α, β, γ, δ, ϵ, πA, πC, πG, πT, safe)
+  GTRrel(α, β, γ, δ, ϵ, πA, πC, πG, πT, safe=safe)
 
 
 function GTR(θ_vec::A,
-               π_vec::A,
+               π_vec::A;
                safe::Bool=true) where A <: AbstractArray
   if safe && length(π_vec) != 4
     error("Incorrect base frequency vector length")
@@ -19,11 +19,11 @@ function GTR(θ_vec::A,
   if length(θ_vec) == 5
     return GTRrel(θ_vec[1], θ_vec[2], θ_vec[3], θ_vec[4], θ_vec[5],
                   π_vec[DNA_A], π_vec[DNA_C], π_vec[DNA_G], π_vec[DNA_T],
-                  safe)
+                  safe=safe)
   elseif length(θ_vec) == 6
     return GTRabs(θ_vec[1], θ_vec[2], θ_vec[3], θ_vec[4], θ_vec[5], θ_vec[6],
                   π_vec[DNA_A], π_vec[DNA_C], π_vec[DNA_G], π_vec[DNA_T],
-                  safe)
+                  safe=safe)
   else
     error("Parameter vector length incompatiable with absolute or relative rate form of substitution model")
   end
@@ -31,7 +31,7 @@ end
 
 
 function GTRrel(θ_vec::A,
-                π_vec::A,
+                π_vec::A;
                 safe::Bool=true) where A <: AbstractArray
   if safe
     if length(θ_vec) != 5
@@ -42,12 +42,12 @@ function GTRrel(θ_vec::A,
   end
   return GTRrel(θ_vec[1], θ_vec[2], θ_vec[3], θ_vec[4], θ_vec[5],
                 π_vec[DNA_A], π_vec[DNA_C], π_vec[DNA_G], π_vec[DNA_T],
-                safe)
+                safe=safe)
 end
 
 
 function GTRabs(θ_vec::A,
-                π_vec::A,
+                π_vec::A;
                 safe::Bool=true) where A <: AbstractArray
   if safe
     if length(θ_vec) != 6
@@ -58,5 +58,5 @@ function GTRabs(θ_vec::A,
   end
   return GTRabs(θ_vec[1], θ_vec[2], θ_vec[3], θ_vec[4], θ_vec[5], θ_vec[6],
                 π_vec[DNA_A], π_vec[DNA_C], π_vec[DNA_G], π_vec[DNA_T],
-                safe)
+                safe=safe)
 end

--- a/src/nucleic_acid/gtr/relative.jl
+++ b/src/nucleic_acid/gtr/relative.jl
@@ -10,7 +10,7 @@ struct GTRrel <: GTR
   πT::Float64
   function GTRrel(α::Float64, β::Float64, γ::Float64,
                   δ::Float64, ϵ::Float64,
-                  πA::Float64, πC::Float64, πG::Float64, πT::Float64,
+                  πA::Float64, πC::Float64, πG::Float64, πT::Float64;
                   safe::Bool=true)
     if safe
       if α <= 0.

--- a/src/nucleic_acid/hky85/absolute.jl
+++ b/src/nucleic_acid/hky85/absolute.jl
@@ -6,7 +6,7 @@ struct HKY85abs <: HKY85
   πG::Float64
   πT::Float64
   function HKY85abs(α::Float64, β::Float64,
-                    πA::Float64, πC::Float64, πG::Float64, πT::Float64,
+                    πA::Float64, πC::Float64, πG::Float64, πT::Float64;
                     safe::Bool=true)
     if safe
       if α <= 0.

--- a/src/nucleic_acid/hky85/outer_constructors.jl
+++ b/src/nucleic_acid/hky85/outer_constructors.jl
@@ -1,25 +1,25 @@
 HKY85(κ::F,
-      πA::F, πC::F, πG::F, πT::F,
+      πA::F, πC::F, πG::F, πT::F;
       safe::Bool=true) where F <: Float64 =
-  HKY85rel(κ, πA, πC, πG, πT, safe)
+  HKY85rel(κ, πA, πC, πG, πT, safe=safe)
 
 
 HKY85(α::F, β::F,
-      πA::F, πC::F, πG::F, πT::F,
+      πA::F, πC::F, πG::F, πT::F;
       safe::Bool=true) where F <: Float64 =
-  HKY85abs(α, β, πA, πC, πG, πT, safe)
+  HKY85abs(α, β, πA, πC, πG, πT, safe=safe)
 
 
 function HKY85(θ_vec::A,
-               π_vec::A,
+               π_vec::A;
                safe::Bool=true) where A <: AbstractArray
   if safe && length(π_vec) != 4
     error("Incorrect base frequency vector length")
   end
   if length(θ_vec) == 1
-    return HKY85rel(θ_vec[1], π_vec[DNA_A], π_vec[DNA_C], π_vec[DNA_G], π_vec[DNA_T], safe)
+    return HKY85rel(θ_vec[1], π_vec[DNA_A], π_vec[DNA_C], π_vec[DNA_G], π_vec[DNA_T], safe=safe)
   elseif length(θ_vec) == 2
-    return HKY85abs(θ_vec[1], θ_vec[2], π_vec[DNA_A], π_vec[DNA_C], π_vec[DNA_G], π_vec[DNA_T], safe)
+    return HKY85abs(θ_vec[1], θ_vec[2], π_vec[DNA_A], π_vec[DNA_C], π_vec[DNA_G], π_vec[DNA_T], safe=safe)
   else
     error("Parameter vector length incompatiable with absolute or relative rate form of substitution model")
   end
@@ -27,7 +27,7 @@ end
 
 
 function HKY85rel(θ_vec::A,
-                  π_vec::A,
+                  π_vec::A;
                   safe::Bool=true) where A <: AbstractArray
   if safe
     if length(θ_vec) != 1
@@ -36,12 +36,12 @@ function HKY85rel(θ_vec::A,
       error("Incorrect base frequency vector length")
     end
   end
-  return HKY85rel(θ_vec[1], π_vec[DNA_A], π_vec[DNA_C], π_vec[DNA_G], π_vec[DNA_T], safe)
+  return HKY85rel(θ_vec[1], π_vec[DNA_A], π_vec[DNA_C], π_vec[DNA_G], π_vec[DNA_T], safe=safe)
 end
 
 
 function HKY85abs(θ_vec::A,
-                  π_vec::A,
+                  π_vec::A;
                   safe::Bool=true) where A <: AbstractArray
   if safe
     if length(θ_vec) != 2
@@ -52,5 +52,5 @@ function HKY85abs(θ_vec::A,
   end
   return HKY85abs(θ_vec[1], θ_vec[2],
                   π_vec[DNA_A], π_vec[DNA_C], π_vec[DNA_G], π_vec[DNA_T],
-                  safe)
+                  safe=safe)
 end

--- a/src/nucleic_acid/hky85/relative.jl
+++ b/src/nucleic_acid/hky85/relative.jl
@@ -5,7 +5,7 @@ struct HKY85rel <: HKY85
   πG::Float64
   πT::Float64
   function HKY85rel(κ::Float64,
-                    πA::Float64, πC::Float64, πG::Float64, πT::Float64,
+                    πA::Float64, πC::Float64, πG::Float64, πT::Float64;
                     safe::Bool=true)
     if safe
       if κ <= 0.

--- a/src/nucleic_acid/jc69/absolute.jl
+++ b/src/nucleic_acid/jc69/absolute.jl
@@ -1,6 +1,6 @@
 struct JC69abs <: JC69
     λ::Float64
-    function JC69abs(λ::Float64, safe::Bool=true)
+    function JC69abs(λ::Float64; safe::Bool=true)
         if safe
           if λ <= 0.
               error("JC69 parameter λ must be positive")

--- a/src/nucleic_acid/jc69/outer_constructors.jl
+++ b/src/nucleic_acid/jc69/outer_constructors.jl
@@ -1,20 +1,20 @@
 JC69() = JC69rel()
-JC69(λ::F, safe::Bool=true) where F <: Float64 = JC69abs(λ, safe)
+JC69(λ::F; safe::Bool=true) where F <: Float64 = JC69abs(λ, safe=safe)
 
 
-function JC69(θ_vec::A,
+function JC69(θ_vec::A;
               safe::Bool=true) where A <: AbstractArray
   if length(θ_vec) == 0
     return JC69rel()
   elseif length(θ_vec) == 1
-    return JC69abs(θ_vec[1], safe)
+    return JC69abs(θ_vec[1], safe=safe)
   else
     error("Parameter vector length incompatiable with absolute or relative rate form of substitution model")
   end
 end
 
 
-function JC69rel(θ_vec::A,
+function JC69rel(θ_vec::A;
                  safe::Bool=true) where A <: AbstractArray
   if safe
     if length(θ_vec) != 0
@@ -25,12 +25,12 @@ function JC69rel(θ_vec::A,
 end
 
 
-function JC69abs(θ_vec::A,
+function JC69abs(θ_vec::A;
                  safe::Bool=true) where A <: AbstractArray
   if safe
     if length(θ_vec) != 1
       error("Incorrect parameter vector length")
     end
   end
-  return  JC69abs(θ_vec[1], safe)
+  return  JC69abs(θ_vec[1], safe=safe)
 end

--- a/src/nucleic_acid/k80/absolute.jl
+++ b/src/nucleic_acid/k80/absolute.jl
@@ -1,7 +1,7 @@
 struct K80abs <: K80
   α::Float64
   β::Float64
-  function K80abs(α::Float64, β::Float64, safe::Bool=true)
+  function K80abs(α::Float64, β::Float64; safe::Bool=true)
     if safe
       if α <= 0.
         error("K80 parameter α must be positive")

--- a/src/nucleic_acid/k80/outer_constructors.jl
+++ b/src/nucleic_acid/k80/outer_constructors.jl
@@ -1,38 +1,38 @@
-K80(κ::Float64, safe::Bool=true) = K80rel(κ, safe)
+K80(κ::Float64; safe::Bool=true) = K80rel(κ, safe=safe)
 
 
-K80(α::Float64, β::Float64, safe::Bool=true) = K80abs(α, β, safe)
+K80(α::Float64, β::Float64; safe::Bool=true) = K80abs(α, β, safe=safe)
 
 
-function K80(θ_vec::A,
+function K80(θ_vec::A;
               safe::Bool=true) where A <: AbstractArray
   if length(θ_vec) == 1
-    return K80rel(θ_vec[1], safe)
+    return K80rel(θ_vec[1], safe=safe)
   elseif length(θ_vec) == 2
-    return K80abs(θ_vec[1], θ_vec[2], safe)
+    return K80abs(θ_vec[1], θ_vec[2], safe=safe)
   else
     error("Parameter vector length incompatiable with absolute or relative rate form of substitution model")
   end
 end
 
 
-function K80rel(θ_vec::A,
+function K80rel(θ_vec::A;
                 safe::Bool=true) where A <: AbstractArray
   if safe
     if length(θ_vec) != 1
       error("Incorrect parameter vector length")
     end
   end
-  return K80rel(θ_vec[1], safe)
+  return K80rel(θ_vec[1], safe=safe)
 end
 
 
-function K80abs(θ_vec::A,
+function K80abs(θ_vec::A;
                 safe::Bool=true) where A <: AbstractArray
   if safe
     if length(θ_vec) != 2
       error("Incorrect parameter vector length")
     end
   end
-  return K80abs(θ_vec[1], θ_vec[2], safe)
+  return K80abs(θ_vec[1], θ_vec[2], safe=safe)
 end

--- a/src/nucleic_acid/k80/relative.jl
+++ b/src/nucleic_acid/k80/relative.jl
@@ -1,6 +1,6 @@
 struct K80rel <: K80
   κ::Float64
-  function K80rel(κ::Float64,
+  function K80rel(κ::Float64;
                   safe::Bool=true)
     if safe
       if κ <= 0.

--- a/src/nucleic_acid/tn93/absolute.jl
+++ b/src/nucleic_acid/tn93/absolute.jl
@@ -7,7 +7,7 @@ struct TN93abs <: TN93
   πG::Float64
   πT::Float64
   function TN93abs(α1::Float64, α2::Float64, β::Float64,
-                   πA::Float64, πC::Float64, πG::Float64, πT::Float64,
+                   πA::Float64, πC::Float64, πG::Float64, πT::Float64;
                    safe::Bool=true)
     if safe
       if α1 <= 0.

--- a/src/nucleic_acid/tn93/outer_constructors.jl
+++ b/src/nucleic_acid/tn93/outer_constructors.jl
@@ -1,11 +1,11 @@
-TN93(α1::F, α2::F, β::F, πA::F, πC::F, πG::F, πT::F, safe::Bool=true) where F <: Float64 = TN93abs(α1, α2, β, πA, πC, πG, πT, safe)
+TN93(α1::F, α2::F, β::F, πA::F, πC::F, πG::F, πT::F; safe::Bool=true) where F <: Float64 = TN93abs(α1, α2, β, πA, πC, πG, πT, safe=safe)
 
 
-TN93(κ1::F, κ2::F, πA::F, πC::F, πG::F, πT::F, safe::Bool=true) where F <: Float64 = TN93rel(κ1, κ2, πA, πC, πG, πT, safe)
+TN93(κ1::F, κ2::F, πA::F, πC::F, πG::F, πT::F; safe::Bool=true) where F <: Float64 = TN93rel(κ1, κ2, πA, πC, πG, πT, safe=safe)
 
 
 function TN93(θ_vec::A,
-              π_vec::A,
+              π_vec::A;
               safe::Bool=true) where A <: AbstractArray
   if safe && length(π_vec) != 4
     error("Incorrect base frequency vector length")
@@ -13,11 +13,11 @@ function TN93(θ_vec::A,
   if length(θ_vec) == 2
     return TN93rel(θ_vec[1], θ_vec[2],
                   π_vec[DNA_A], π_vec[DNA_C], π_vec[DNA_G], π_vec[DNA_T],
-                  safe)
+                  safe=safe)
   elseif length(θ_vec) == 3
     return TN93abs(θ_vec[1], θ_vec[2], θ_vec[3],
                   π_vec[DNA_A], π_vec[DNA_C], π_vec[DNA_G], π_vec[DNA_T],
-                  safe)
+                  safe=safe)
   else
     error("Parameter vector length incompatiable with absolute or relative rate form of substitution model")
   end
@@ -25,7 +25,7 @@ end
 
 
 function TN93rel(θ_vec::A,
-                 π_vec::A,
+                 π_vec::A;
                  safe::Bool=true) where A <: AbstractArray
   if safe
     if length(θ_vec) != 2
@@ -34,12 +34,12 @@ function TN93rel(θ_vec::A,
       error("Incorrect base frequency vector length")
     end
   end
-  return TN93rel(θ_vec[1], θ_vec[2], π_vec[DNA_A], π_vec[DNA_C], π_vec[DNA_G], π_vec[DNA_T], safe)
+  return TN93rel(θ_vec[1], θ_vec[2], π_vec[DNA_A], π_vec[DNA_C], π_vec[DNA_G], π_vec[DNA_T], safe=safe)
 end
 
 
 function TN93abs(θ_vec::A,
-                 π_vec::A,
+                 π_vec::A;
                  safe::Bool=true) where A <: AbstractArray
   if safe
     if length(θ_vec) != 3
@@ -48,5 +48,5 @@ function TN93abs(θ_vec::A,
       error("Incorrect base frequency vector length")
     end
   end
-  return TN93abs(θ_vec[1], θ_vec[2], θ_vec[3], π_vec[DNA_A], π_vec[DNA_C], π_vec[DNA_G], π_vec[DNA_T], safe)
+  return TN93abs(θ_vec[1], θ_vec[2], θ_vec[3], π_vec[DNA_A], π_vec[DNA_C], π_vec[DNA_G], π_vec[DNA_T], safe=safe)
 end

--- a/src/nucleic_acid/tn93/relative.jl
+++ b/src/nucleic_acid/tn93/relative.jl
@@ -6,7 +6,7 @@ struct TN93rel <: TN93
   πG::Float64
   πT::Float64
   function TN93rel(κ1::Float64, κ2::Float64,
-                   πA::Float64, πC::Float64, πG::Float64, πT::Float64,
+                   πA::Float64, πC::Float64, πG::Float64, πT::Float64;
                    safe::Bool=true)
     if safe
       if κ1 <= 0.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,14 +17,14 @@ function test_mod_fun(mod::Type{T}, n_params::Int64, equal_base_freqs::Bool, clo
   if equal_base_freqs
     @test_throws ErrorException convert(mod, _dummy_params[1:n_params+1], safe=true)
     if n_params > 0
-      @test_throws BoundsError mod(_dummy_params[1:n_params-1], false) # safe = false
+      @test_throws BoundsError mod(_dummy_params[1:n_params-1], safe=false)
     end
-    @test_nowarn mod(_dummy_params[1:n_params+1], false) # safe = false
+    @test_nowarn mod(_dummy_params[1:n_params+1], safe=false)
     for i in 1:n_params
       flip = fill(1.0, n_params)
       flip[i] *= -1
       @test_throws ErrorException convert(mod, _dummy_params[1:n_params] .* flip, safe=true)
-      @test_nowarn mod(_dummy_params[1:n_params] .* flip, false) # safe = false
+      @test_nowarn mod(_dummy_params[1:n_params] .* flip, safe=false)
     end
     @test_throws MethodError convert(mod, _dummy_params[1:n_params], _dummy_freqs)
     @test_nowarn convert(mod, _dummy_params[1:n_params], safe=true)
@@ -33,18 +33,18 @@ function test_mod_fun(mod::Type{T}, n_params::Int64, equal_base_freqs::Bool, clo
   else
     @test_throws ErrorException convert(mod, _dummy_params[1:n_params+1], _dummy_freqs)
     if n_params > 0
-      @test_throws BoundsError mod(_dummy_params[1:n_params-1], _dummy_freqs, false) # safe = false
+      @test_throws BoundsError mod(_dummy_params[1:n_params-1], _dummy_freqs, safe=false)
     end
     for i in 1:n_params
       flip = fill(1.0, n_params)
       flip[i] *= -1
       @test_throws ErrorException convert(mod, _dummy_params[1:n_params] .* flip, _dummy_freqs)
-      @test_nowarn mod(_dummy_params[1:n_params] .* flip, _dummy_freqs, false) # safe = false
+      @test_nowarn mod(_dummy_params[1:n_params] .* flip, _dummy_freqs, safe=false)
     end
     @test_throws ErrorException convert(mod, _dummy_params[1:n_params], _dummy_freqs .+ 0.1)
     @test_throws ErrorException convert(mod, _dummy_params[1:n_params], _dummy_freqs[1:3])
-    @test_nowarn mod(_dummy_params[1:n_params], [_dummy_freqs; 0.1], false) # safe = false
-    @test_throws BoundsError mod(_dummy_params[1:n_params], _dummy_freqs[1:3], false) # safe = false
+    @test_nowarn mod(_dummy_params[1:n_params], [_dummy_freqs; 0.1], safe=false)
+    @test_throws BoundsError mod(_dummy_params[1:n_params], _dummy_freqs[1:3], safe=false)
     @test_throws MethodError convert(mod, _dummy_params[1:n_params])
     @test_nowarn convert(mod, _dummy_params[1:n_params], _dummy_freqs, safe=true)
     x = mod(_dummy_params[1:n_params], _dummy_freqs)


### PR DESCRIPTION
This PR implements more consistency over constructor safety syntax (now always a keyword argument).

This PR should also result in documenter running again